### PR TITLE
CI: Add step that uploads Android APK as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Android app
         run: bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+      - name: Upload Android APK as artifact
+        uses: actions/upload-artifact@v2
+        if: github.repository_owner == 'google'
+        with:
+          path: bazel-bin/android_example/lyra_android_example.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
         if: github.repository_owner == 'google'
         with:
           path: bazel-bin/android_example/lyra_android_example.apk
+          retention-days: 30


### PR DESCRIPTION
This PR adds a step to the Android app build job that uploads the generated APK. Currently configured to only run on the google/lyra repo.

The APK won't be deployed to releases or something, but only uploaded as build artifact. This enables the ability for developers to quickly test their changes on a standardized and reproduceable build.

This bit was left out #5 and can be discussed here further.