### PR TITLE
Add required Bazel version (4.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ version available in their application repositories, so make sure you are
 using the required version or newer. The latest version can be downloaded via
 [Github](https://github.com/bazelbuild/bazel/releases).
 
-
 Lyra can be built from linux using bazel for an arm android target, or a linux
 target.  The android target is optimized for realtime performance.  The linux
 target is typically used for development and debugging.

--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ There are a few things you'll need to do to set up your computer to build Lyra.
 
 ### Common setup
 
-Lyra is built using Google's build system, Bazel.  Install it following these
+Lyra is built using Google's build system, Bazel. Install it following these
 [instructions](https://docs.bazel.build/versions/master/install.html).
+Bazel verson 4.0.0 is required, and some Linux distributions may make an older
+version available in their application repositories, so make sure you are 
+using the required version or newer. The latest version can be downloaded via
+[Github](https://github.com/bazelbuild/bazel/releases).
+
 
 Lyra can be built from linux using bazel for an arm android target, or a linux
 target.  The android target is optimized for realtime performance.  The linux


### PR DESCRIPTION
After trying to compile on Debian bullseye, it was pointed out to me (see https://github.com/google/lyra/issues/10) that Bazel 4.0.0 is required for the build commands to work correctly. This PR mentions this requirement in the README.