### PR TITLE
Build Lyra with Bazel 5.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,22 +102,31 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-      - name: Build encoder_main
+      - name: Show default shell
         run: |
-          set ANDROID_NDK_HOME="%ANDROID_HOME%\ndk\21.4.7075529"
+          echo $SHELL
+      - name: Build encoder_main
+        shell: bash
+        run: |
+          echo $SHELL
+          echo $ANDROID_NDK_HOME
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          echo $ANDROID_NDK_HOME
           bazel build -c opt :encoder_main
       - name: Build decoder_main
+        shell: bash
         run: |
-          set ANDROID_NDK_HOME="%ANDROID_HOME%\ndk\21.4.7075529"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
       - name: Move artifacts
+        shell: bash
         run: |
           mkdir action-product
-          xcopy wavegru action-product\
-          copy bazel-bin\encoder_main.exe action-product\lyra-encoder.exe
-          copy bazel-bin\decoder_main.exe action-product\lyra-decoder.exe
+          cp -r wavegru action-product/
+          cp bazel-bin/encoder_main.exe action-product/lyra-encoder.exe
+          cp bazel-bin/decoder_main.exe action-product/lyra-decoder.exe
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,48 @@ jobs:
         with:
           name: lyra-macos-amd64
           path: action-product
+
+  android-bin-arm64-from-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build encoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :encoder_main --config=android_arm64
+      - name: Build decoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :decoder_main --config=android_arm64
+      - name: Move artifacts
+        run: |
+          mkdir action-product
+          cp -r wavegru ./action-product/
+          cp bazel-bin/encoder_main ./action-product/lyra-encoder
+          cp bazel-bin/decoder_main ./action-product/lyra-decoder
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-android-arm64
+          path: action-product
+
+  android-app-arm64-from-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build Android App
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+      - name: Move artifacts
+        run: |
+          mkdir action-product
+          cp bazel-bin/android_example/lyra_android_example.apk ./action-product/
+          cp bazel-bin/android_example/lyra_android_example_unsigned.apk ./action-product/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: android-example
+          path: action-product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,51 +6,57 @@ jobs:
   android-bin-arm64:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout repo
         uses: actions/checkout@v2
-      - name: build encoder_main
+      - name: Build encoder_main
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :encoder_main --config=android_arm64
-      - name: build decoder_main
+      - name: Build decoder_main
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main --config=android_arm64
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
   android-app-arm64:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout repo
         uses: actions/checkout@v2
-      - name: build android app
+      - name: Build Android App
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
-  linux-bin-arm64:
+  linux-bin-amd64:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout repo
         uses: actions/checkout@v2
-      - name: build encoder_main
+      - name: Build encoder_main
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :encoder_main
-      - name: build decoder_main
+      - name: Build decoder_main
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
 
-  darwin-bin-arm64:
+  darwin-bin-amd64:
     runs-on: macos-latest
     steps:
-      - name: checkout
+      - name: Checkout repo
         uses: actions/checkout@v2
-      - name: build encoder_main
+      - name: Build encoder_main
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :encoder_main
-      - name: build decoder_main
+      - name: Build decoder_main
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  android-bin-arm64:
+  android-bin:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -16,7 +16,7 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main --config=android_arm64
-      - name: Move artifacts
+      - name: Copy artifacts
         run: |
           mkdir action-product
           cp -r wavegru action-product/
@@ -28,7 +28,7 @@ jobs:
           name: lyra-android-bin
           path: action-product
 
-  android-app-arm64:
+  android-app:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -37,7 +37,7 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
-      - name: Move artifacts
+      - name: Copy artifacts
         run: |
           mkdir action-product
           cp bazel-bin/android_example/lyra_android_example.apk action-product/lyra_example.apk
@@ -47,7 +47,7 @@ jobs:
           name: lyra-android-example
           path: action-product
 
-  linux-bin-amd64:
+  linux-amd64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -60,7 +60,7 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
-      - name: Move artifacts
+      - name: Copy artifacts
         run: |
           mkdir action-product
           cp -r wavegru action-product/
@@ -72,7 +72,7 @@ jobs:
           name: lyra-linux-amd64
           path: action-product
 
-  darwin-bin-amd64:
+  macos-amd64:
     runs-on: macos-latest
     steps:
       - name: Checkout repo
@@ -85,7 +85,7 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
-      - name: Move artifacts
+      - name: Copy artifacts
         run: |
           mkdir action-product
           cp -r wavegru action-product/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: push
 
 jobs:
   android-bin-arm64:
@@ -16,20 +16,31 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main --config=android_arm64
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Zip artifact
+        run: |
+          mkdir action-product
+          cp -r wavegru ./action-product/
+          cp bazel-bin/encoder_main ./action-product/lyra-encoder
+          cp bazel-bin/decoder_main ./action-product/lyra-decoder
+          cd action-product
+          zip -r lyra.zip ./*
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-android-arm64
+          path: action-product/lyra.zip
 
   android-app-arm64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Build Android App
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
   linux-bin-amd64:
     runs-on: ubuntu-latest
@@ -44,6 +55,19 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
+      - name: Zip artifact
+        run: |
+          mkdir action-product
+          cp -r wavegru ./action-product/
+          cp bazel-bin/encoder_main ./action-product/lyra-encoder
+          cp bazel-bin/decoder_main ./action-product/lyra-decoder
+          cd action-product
+          zip -r lyra.zip ./*
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-linux-amd64
+          path: action-product/lyra.zip
 
   darwin-bin-amd64:
     runs-on: macos-latest
@@ -58,5 +82,16 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Zip artifact
+        run: |
+          mkdir action-product
+          cp -r wavegru ./action-product/
+          cp bazel-bin/encoder_main ./action-product/lyra-encoder
+          cp bazel-bin/decoder_main ./action-product/lyra-decoder
+          cd action-product
+          zip -r lyra.zip ./*
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-macos-amd64
+          path: action-product/lyra.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: push
+on: [push, pull_request]
 
 jobs:
   android-bin-arm64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,47 +98,29 @@ jobs:
           name: lyra-macos-amd64
           path: action-product
 
-  android-bin-arm64-from-macos:
-    runs-on: macos-latest
+  windows-bin-amd64:
+    runs-on: windows-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Build encoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :encoder_main --config=android_arm64
+          set ANDROID_NDK_HOME="%ANDROID_HOME%/ndk/21.4.7075529"
+          bazel build -c opt :encoder_main
       - name: Build decoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :decoder_main --config=android_arm64
-      - name: Move artifacts
-        run: |
-          mkdir action-product
-          cp -r wavegru ./action-product/
-          cp bazel-bin/encoder_main ./action-product/lyra-encoder
-          cp bazel-bin/decoder_main ./action-product/lyra-decoder
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: lyra-android-arm64
-          path: action-product
-
-  android-app-arm64-from-macos:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Build Android App
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
-      - name: Move artifacts
-        run: |
-          mkdir action-product
-          cp bazel-bin/android_example/lyra_android_example.apk ./action-product/
-          cp bazel-bin/android_example/lyra_android_example_unsigned.apk ./action-product/
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: android-example
-          path: action-product
+          set ANDROID_NDK_HOME="%ANDROID_HOME%/ndk/21.4.7075529"
+          bazel build -c opt :decoder_main
+      # - name: Move artifacts
+      #   run: |
+      #     mkdir action-product
+      #     cp -r wavegru ./action-product/
+      #     cp bazel-bin/encoder_main ./action-product/lyra-encoder
+      #     cp bazel-bin/decoder_main ./action-product/lyra-decoder
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: lyra-android-arm64
+      #     path: action-product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,12 @@ jobs:
           path: action-product
 
   windows-bin-amd64:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Build encoder_main
         run: |
           set ANDROID_NDK_HOME="%ANDROID_HOME%\ndk\21.4.7075529"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,39 +96,3 @@ jobs:
         with:
           name: lyra-macos-amd64
           path: action-product
-
-  windows-bin-amd64:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Show default shell
-        run: |
-          echo $SHELL
-      - name: Build encoder_main
-        shell: bash
-        run: |
-          echo $SHELL
-          echo $ANDROID_NDK_HOME
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          echo $ANDROID_NDK_HOME
-          bazel build -c opt :encoder_main
-      - name: Build decoder_main
-        shell: bash
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :decoder_main
-      - name: Move artifacts
-        shell: bash
-        run: |
-          mkdir action-product
-          cp -r wavegru action-product/
-          cp bazel-bin/encoder_main.exe action-product/lyra-encoder.exe
-          cp bazel-bin/decoder_main.exe action-product/lyra-decoder.exe
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: lyra-windows-amd64
-          path: action-product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
         uses: actions/checkout@v2
       - name: build encoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :encoder_main --config=android_arm64
       - name: build decoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main --config=android_arm64
 
   android-app-arm64:
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
       - name: build android app
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
 
   linux-bin-arm64:
@@ -34,11 +34,11 @@ jobs:
         uses: actions/checkout@v2
       - name: build encoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :encoder_main
       - name: build decoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
 
   darwin-bin-arm64:
@@ -48,9 +48,9 @@ jobs:
         uses: actions/checkout@v2
       - name: build encoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :encoder_main
       - name: build decoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,56 @@
+name: build
+
 on: [push, pull_request]
 
 jobs:
-  android-bin:
+  android-bin-arm64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: bazel build -c opt :encoder_main --config=android_arm64
-      - run: bazel build -c opt :decoder_main --config=android_arm64
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: build encoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          bazel build -c opt :encoder_main --config=android_arm64
+      - name: build decoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          bazel build -c opt :decoder_main --config=android_arm64
 
-  android-app:
+  android-app-arm64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build Android app
-        run: bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: build android app
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+
+  linux-bin-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: build encoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          bazel build -c opt :encoder_main
+      - name: build decoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          bazel build -c opt :decoder_main
+
+  darwin-bin-arm64:
+    runs-on: macos-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: build encoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          bazel build -c opt :encoder_main
+      - name: build decoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/23.1.7779620"
+          bazel build -c opt :decoder_main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lyra-android-arm64
+          name: lyra-android-bin
           path: action-product
 
   android-app-arm64:
@@ -40,12 +40,11 @@ jobs:
       - name: Move artifacts
         run: |
           mkdir action-product
-          cp bazel-bin/android_example/lyra_android_example.apk ./action-product/
-          cp bazel-bin/android_example/lyra_android_example_unsigned.apk ./action-product/
+          cp bazel-bin/android_example/lyra_android_example.apk ./action-product/lyra_example.apk
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: android-example
+          name: lyra-android-example
           path: action-product
 
   linux-bin-amd64:
@@ -107,20 +106,20 @@ jobs:
         uses: mxschmitt/action-tmate@v3
       - name: Build encoder_main
         run: |
-          set ANDROID_NDK_HOME="%ANDROID_HOME%/ndk/21.4.7075529"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :encoder_main
       - name: Build decoder_main
         run: |
-          set ANDROID_NDK_HOME="%ANDROID_HOME%/ndk/21.4.7075529"
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
-      # - name: Move artifacts
-      #   run: |
-      #     mkdir action-product
-      #     cp -r wavegru ./action-product/
-      #     cp bazel-bin/encoder_main ./action-product/lyra-encoder
-      #     cp bazel-bin/decoder_main ./action-product/lyra-decoder
-      # - name: Upload artifact
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: lyra-android-arm64
-      #     path: action-product
+      - name: Move artifacts
+        run: |
+          mkdir action-product
+          cp -r wavegru ./action-product/
+          cp bazel-bin/encoder_main.exe ./action-product/lyra-encoder.exe
+          cp bazel-bin/decoder_main.exe ./action-product/lyra-decoder.exe
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-windows-amd64
+          path: action-product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Move artifacts
         run: |
           mkdir action-product
-          cp -r wavegru ./action-product/
-          cp bazel-bin/encoder_main ./action-product/lyra-encoder
-          cp bazel-bin/decoder_main ./action-product/lyra-decoder
+          cp -r wavegru action-product/
+          cp bazel-bin/encoder_main action-product/lyra-encoder
+          cp bazel-bin/decoder_main action-product/lyra-decoder
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
@@ -40,7 +40,7 @@ jobs:
       - name: Move artifacts
         run: |
           mkdir action-product
-          cp bazel-bin/android_example/lyra_android_example.apk ./action-product/lyra_example.apk
+          cp bazel-bin/android_example/lyra_android_example.apk action-product/lyra_example.apk
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
@@ -63,9 +63,9 @@ jobs:
       - name: Move artifacts
         run: |
           mkdir action-product
-          cp -r wavegru ./action-product/
-          cp bazel-bin/encoder_main ./action-product/lyra-encoder
-          cp bazel-bin/decoder_main ./action-product/lyra-decoder
+          cp -r wavegru action-product/
+          cp bazel-bin/encoder_main action-product/lyra-encoder
+          cp bazel-bin/decoder_main action-product/lyra-decoder
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
@@ -88,9 +88,9 @@ jobs:
       - name: Move artifacts
         run: |
           mkdir action-product
-          cp -r wavegru ./action-product/
-          cp bazel-bin/encoder_main ./action-product/lyra-encoder
-          cp bazel-bin/decoder_main ./action-product/lyra-decoder
+          cp -r wavegru action-product/
+          cp bazel-bin/encoder_main action-product/lyra-encoder
+          cp bazel-bin/decoder_main action-product/lyra-decoder
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
@@ -104,18 +104,18 @@ jobs:
         uses: actions/checkout@v2
       - name: Build encoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME\ndk\21.4.7075529"
+          set ANDROID_NDK_HOME="%ANDROID_HOME%\ndk\21.4.7075529"
           bazel build -c opt :encoder_main
       - name: Build decoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME\ndk\21.4.7075529"
+          set ANDROID_NDK_HOME="%ANDROID_HOME%\ndk\21.4.7075529"
           bazel build -c opt :decoder_main
       - name: Move artifacts
         run: |
           mkdir action-product
-          cp -r wavegru ./action-product/
-          cp bazel-bin/encoder_main.exe ./action-product/lyra-encoder.exe
-          cp bazel-bin/decoder_main.exe ./action-product/lyra-decoder.exe
+          xcopy wavegru action-product\
+          copy bazel-bin\encoder_main.exe action-product\lyra-encoder.exe
+          copy bazel-bin\decoder_main.exe action-product\lyra-decoder.exe
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,31 +16,29 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main --config=android_arm64
-      - name: Zip artifact
+      - name: Move artifacts
         run: |
           mkdir action-product
           cp -r wavegru ./action-product/
           cp bazel-bin/encoder_main ./action-product/lyra-encoder
           cp bazel-bin/decoder_main ./action-product/lyra-decoder
-          cd action-product
-          zip -r lyra.zip ./*
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lyra-android-arm64
-          path: action-product/lyra.zip
+          name: lyra-android-arm64.zip
+          path: action-product
 
   android-app-arm64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Build Android App
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
   linux-bin-amd64:
     runs-on: ubuntu-latest
@@ -55,19 +53,17 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
-      - name: Zip artifact
+      - name: Move artifacts
         run: |
           mkdir action-product
           cp -r wavegru ./action-product/
           cp bazel-bin/encoder_main ./action-product/lyra-encoder
           cp bazel-bin/decoder_main ./action-product/lyra-decoder
-          cd action-product
-          zip -r lyra.zip ./*
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lyra-linux-amd64
-          path: action-product/lyra.zip
+          name: lyra-linux-amd64.zip
+          path: action-product/*
 
   darwin-bin-amd64:
     runs-on: macos-latest
@@ -82,16 +78,14 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build -c opt :decoder_main
-      - name: Zip artifact
+      - name: Move artifacts
         run: |
           mkdir action-product
           cp -r wavegru ./action-product/
           cp bazel-bin/encoder_main ./action-product/lyra-encoder
           cp bazel-bin/decoder_main ./action-product/lyra-decoder
-          cd action-product
-          zip -r lyra.zip ./*
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lyra-macos-amd64
-          path: action-product/lyra.zip
+          name: lyra-macos-amd64.zip
+          path: action-product/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           path: action-product
 
   windows-bin-amd64:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lyra-android-arm64.zip
+          name: lyra-android-arm64
           path: action-product
 
   android-app-arm64:
@@ -37,8 +37,16 @@ jobs:
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Move artifacts
+        run: |
+          mkdir action-product
+          cp bazel-bin/android_example/lyra_android_example.apk ./action-product/
+          cp bazel-bin/android_example/lyra_android_example_unsigned.apk ./action-product/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: android-example
+          path: action-product
 
   linux-bin-amd64:
     runs-on: ubuntu-latest
@@ -62,8 +70,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lyra-linux-amd64.zip
-          path: action-product/*
+          name: lyra-linux-amd64
+          path: action-product
 
   darwin-bin-amd64:
     runs-on: macos-latest
@@ -87,5 +95,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: lyra-macos-amd64.zip
-          path: action-product/*
+          name: lyra-macos-amd64
+          path: action-product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,15 +102,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Build encoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          export ANDROID_NDK_HOME="$ANDROID_HOME\ndk\21.4.7075529"
           bazel build -c opt :encoder_main
       - name: Build decoder_main
         run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          export ANDROID_NDK_HOME="$ANDROID_HOME\ndk\21.4.7075529"
           bazel build -c opt :decoder_main
       - name: Move artifacts
         run: |

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64` (type `ls /usr/lib/jvm` to see
 which path was installed) to your $HOME/.bashrc and reload it with `source
 $HOME/.bashrc`.
 
-4. Install the r21 ndk, android sdk 31, and build tools:
+4. Install the r21 ndk, android sdk 30, and build tools:
 
 ``` shell
-bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-31" "build-tools;31.0.0" "ndk;21.4.7075529"
+bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-30" "build-tools;30.0.3" "ndk;21.4.7075529"
 ```
 
 5. Add the following to .bashrc (or export the variables)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are a few things you'll need to do to set up your computer to build Lyra.
 
 Lyra is built using Google's build system, Bazel. Install it following these
 [instructions](https://docs.bazel.build/versions/master/install.html).
-Bazel verson 4.0.0 is required, and some Linux distributions may make an older
+Bazel verson 4.0.0 or newer is required, and some Linux distributions may make an older
 version available in their application repositories, so make sure you are
 using the required version or newer. The latest version can be downloaded via
 [Github](https://github.com/bazelbuild/bazel/releases).
@@ -74,16 +74,16 @@ JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64` (type `ls /usr/lib/jvm` to see
 which path was installed) to your $HOME/.bashrc and reload it with `source
 $HOME/.bashrc`.
 
-4. Install the r21 ndk, android sdk 29, and build tools:
+4. Install the r23 ndk, android sdk 31, and build tools:
 
 ``` shell
-bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-29" "build-tools;29.0.3" "ndk;21.4.7075529"
+bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-31" "build-tools;31.0.0" "ndk;23.1.7779620"
 ```
 
 5. Add the following to .bashrc (or export the variables)
 
 ``` shell
-export ANDROID_NDK_HOME=$HOME/android/sdk/ndk/21.4.7075529
+export ANDROID_NDK_HOME=$HOME/android/sdk/ndk/23.1.7779620
 export ANDROID_HOME=$HOME/android/sdk
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64` (type `ls /usr/lib/jvm` to see
 which path was installed) to your $HOME/.bashrc and reload it with `source
 $HOME/.bashrc`.
 
-4. Install the r23 ndk, android sdk 31, and build tools:
+4. Install the r21 ndk, android sdk 31, and build tools:
 
 ``` shell
-bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-31" "build-tools;31.0.0" "ndk;23.1.7779620"
+bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-31" "build-tools;31.0.0" "ndk;21.4.7075529"
 ```
 
 5. Add the following to .bashrc (or export the variables)
 
 ``` shell
-export ANDROID_NDK_HOME=$HOME/android/sdk/ndk/23.1.7779620
+export ANDROID_NDK_HOME=$HOME/android/sdk/ndk/21.4.7075529
 export ANDROID_HOME=$HOME/android/sdk
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are a few things you'll need to do to set up your computer to build Lyra.
 
 Lyra is built using Google's build system, Bazel. Install it following these
 [instructions](https://docs.bazel.build/versions/master/install.html).
-Bazel verson 4.0.0 or newer is required, and some Linux distributions may make an older
+Bazel verson 5.0.0 is required, and some Linux distributions may make an older
 version available in their application repositories, so make sure you are
 using the required version or newer. The latest version can be downloaded via
 [Github](https://github.com/bazelbuild/bazel/releases).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,13 +117,13 @@ bazel_skylib_workspace()
 
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 29,
-    build_tools_version = "29.0.3"
+    api_level = 31,
+    build_tools_version = "31.0.0"
 )
 
 android_ndk_repository(
     name = "androidndk",
-    api_level = 29
+    api_level = 31
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,13 +117,13 @@ bazel_skylib_workspace()
 
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 31,
-    build_tools_version = "31.0.0"
+    api_level = 30,
+    build_tools_version = "30.0.3"
 )
 
 android_ndk_repository(
     name = "androidndk",
-    api_level = 31
+    api_level = 30
 )
 
 http_archive(

--- a/android_example/AndroidManifest.xml
+++ b/android_example/AndroidManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.example.android.lyra">
-    <uses-sdk android:minSdkVersion="29" />
+    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application tools:replace="android:icon"
                  android:extractNativeLibs="true"

--- a/android_example/AndroidManifest.xml
+++ b/android_example/AndroidManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.example.android.lyra">
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31" />
+    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="30" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application tools:replace="android:icon"
                  android:extractNativeLibs="true"

--- a/android_example/LibraryManifest.xml
+++ b/android_example/LibraryManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.lyra">
 
-    <uses-sdk android:minSdkVersion="29" />
+    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31" />
 
     <application
         android:allowBackup="true"

--- a/android_example/LibraryManifest.xml
+++ b/android_example/LibraryManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.lyra">
 
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="31" />
+    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="30" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
In the ubuntu-latest and macos-latest virtual environments, the default Bazel version is 5.0.0, which requires build-tools 30.0.0 or newer version to work properly. Lyra is currently using build-tools 29.0.3, which will cause Lyra failed to build with the default Bazel in GitHub Actions virtual environments.

This change will build Lyra with:

- `Bazel 5.0.0`
- `build-tools 30.0.3`
- `platforms android-30`
- `ndk 21.4.7075529` (unchanged)



Built successfully on hosts:

- `Ubuntu 20.04 (amd64)`
  - `linux-bin` ✅
  - `android-bin` ✅
  - `android-app` ✅
- `macOS 11 (Intel)`
  - `macos-bin` ✅
  - `android-bin` ❌
  - `android-app` ❌
- `macOS 12.2 (Apple Silicon)`
  - `macos-bin` ✅
  - `android-bin` ❌
  - `android-app` ❌
