### PR TITLE
Build Lyra with Bazel 5.0.0

### DIFF
--- a/.github/actions/lyra-builder/action.yml
+++ b/.github/actions/lyra-builder/action.yml
@@ -1,0 +1,37 @@
+name: lyra-builder
+
+description: Build lyra binary on different platforms
+
+inputs:
+  platform:
+    description: Platform to build
+    required: true
+  architecture:
+    description: Architecture to build
+    required: true
+  build-options:
+    description: Options in bazel build command
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+        bazel build -c opt :encoder_main ${{ inputs.build-options }}
+    - shell: bash
+      run: |
+        export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+        bazel build -c opt :decoder_main ${{ inputs.build-options }}
+    - shell: bash
+      run: |
+        mkdir action-product
+        cp -r wavegru action-product/
+        cp bazel-bin/encoder_main action-product/lyra-encoder
+        cp bazel-bin/decoder_main action-product/lyra-decoder
+    - uses: actions/upload-artifact@v2
+      with:
+        name: lyra-${{ inputs.platform }}-${{ inputs.architecture }}
+        path: action-product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,41 +3,18 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  android-bin:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Build encoder_main
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :encoder_main --config=android_arm64
-      - name: Build decoder_main
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :decoder_main --config=android_arm64
-      - name: Copy artifacts
-        run: |
-          mkdir action-product
-          cp -r wavegru action-product/
-          cp bazel-bin/encoder_main action-product/lyra-encoder
-          cp bazel-bin/decoder_main action-product/lyra-decoder
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: lyra-android-bin
-          path: action-product
-
-  android-app:
+  android-example:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Build Android App
+        shell: bash
         run: |
           export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
           bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
       - name: Copy artifacts
+        shell: bash
         run: |
           mkdir action-product
           cp bazel-bin/android_example/lyra_android_example.apk action-product/lyra_example.apk
@@ -47,52 +24,36 @@ jobs:
           name: lyra-android-example
           path: action-product
 
+  android-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build and upload
+        uses: ./.github/actions/lyra-builder
+        with:
+          platform: android
+          architecture: arm64
+          build-options: --config=android_arm64
+
   linux-amd64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Build encoder_main
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :encoder_main
-      - name: Build decoder_main
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :decoder_main
-      - name: Copy artifacts
-        run: |
-          mkdir action-product
-          cp -r wavegru action-product/
-          cp bazel-bin/encoder_main action-product/lyra-encoder
-          cp bazel-bin/decoder_main action-product/lyra-decoder
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
+      - name: Build and upload
+        uses: ./.github/actions/lyra-builder
         with:
-          name: lyra-linux-amd64
-          path: action-product
+          platform: linux
+          architecture: amd64
 
   macos-amd64:
     runs-on: macos-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - name: Build encoder_main
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :encoder_main
-      - name: Build decoder_main
-        run: |
-          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
-          bazel build -c opt :decoder_main
-      - name: Copy artifacts
-        run: |
-          mkdir action-product
-          cp -r wavegru action-product/
-          cp bazel-bin/encoder_main action-product/lyra-encoder
-          cp bazel-bin/decoder_main action-product/lyra-decoder
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
+      - name: Build and upload
+        uses: ./.github/actions/lyra-builder
         with:
-          name: lyra-macos-amd64
-          path: action-product
+          platform: macos
+          architecture: amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,98 @@
+name: build
+
 on: [push, pull_request]
 
 jobs:
   android-bin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: bazel build -c opt :encoder_main --config=android_arm64
-      - run: bazel build -c opt :decoder_main --config=android_arm64
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build encoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :encoder_main --config=android_arm64
+      - name: Build decoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :decoder_main --config=android_arm64
+      - name: Copy artifacts
+        run: |
+          mkdir action-product
+          cp -r wavegru action-product/
+          cp bazel-bin/encoder_main action-product/lyra-encoder
+          cp bazel-bin/decoder_main action-product/lyra-decoder
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-android-bin
+          path: action-product
 
   android-app:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build Android app
-        run: bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build Android App
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build android_example:lyra_android_example --config=android_arm64 --copt=-DBENCHMARK
+      - name: Copy artifacts
+        run: |
+          mkdir action-product
+          cp bazel-bin/android_example/lyra_android_example.apk action-product/lyra_example.apk
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-android-example
+          path: action-product
+
+  linux-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build encoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :encoder_main
+      - name: Build decoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :decoder_main
+      - name: Copy artifacts
+        run: |
+          mkdir action-product
+          cp -r wavegru action-product/
+          cp bazel-bin/encoder_main action-product/lyra-encoder
+          cp bazel-bin/decoder_main action-product/lyra-decoder
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-linux-amd64
+          path: action-product
+
+  macos-amd64:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Build encoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :encoder_main
+      - name: Build decoder_main
+        run: |
+          export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/21.4.7075529"
+          bazel build -c opt :decoder_main
+      - name: Copy artifacts
+        run: |
+          mkdir action-product
+          cp -r wavegru action-product/
+          cp bazel-bin/encoder_main action-product/lyra-encoder
+          cp bazel-bin/decoder_main action-product/lyra-decoder
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: lyra-macos-amd64
+          path: action-product

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ There are a few things you'll need to do to set up your computer to build Lyra.
 
 Lyra is built using Google's build system, Bazel. Install it following these
 [instructions](https://docs.bazel.build/versions/master/install.html).
-Bazel verson 4.0.0 is required, and some Linux distributions may make an older
+Bazel verson 5.0.0 is required, and some Linux distributions may make an older
 version available in their application repositories, so make sure you are
 using the required version or newer. The latest version can be downloaded via
 [Github](https://github.com/bazelbuild/bazel/releases).
@@ -74,10 +74,10 @@ JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64` (type `ls /usr/lib/jvm` to see
 which path was installed) to your $HOME/.bashrc and reload it with `source
 $HOME/.bashrc`.
 
-4. Install the r21 ndk, android sdk 29, and build tools:
+4. Install the r21 ndk, android sdk 30, and build tools:
 
 ``` shell
-bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-29" "build-tools;29.0.3" "ndk;21.4.7075529"
+bin/sdkmanager  --sdk_root=$HOME/android/sdk --install  "platforms;android-30" "build-tools;30.0.3" "ndk;21.4.7075529"
 ```
 
 5. Add the following to .bashrc (or export the variables)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,13 +117,13 @@ bazel_skylib_workspace()
 
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 29,
-    build_tools_version = "29.0.3"
+    api_level = 30,
+    build_tools_version = "30.0.3"
 )
 
 android_ndk_repository(
     name = "androidndk",
-    api_level = 29
+    api_level = 30
 )
 
 http_archive(

--- a/android_example/AndroidManifest.xml
+++ b/android_example/AndroidManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="com.example.android.lyra">
-    <uses-sdk android:minSdkVersion="29" />
+    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="30" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application tools:replace="android:icon"
                  android:extractNativeLibs="true"

--- a/android_example/LibraryManifest.xml
+++ b/android_example/LibraryManifest.xml
@@ -18,7 +18,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.lyra">
 
-    <uses-sdk android:minSdkVersion="29" />
+    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="30" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
**This fixes #76.**

In the ubuntu-latest and macos-latest virtual environments, the default Bazel version is 5.0.0, which requires build-tools 30.0.0 or newer version to work properly. Lyra is currently using build-tools 29.0.3, which will cause Lyra failed to build with the default Bazel in GitHub Actions virtual environments.

This change will build Lyra with:

- `Bazel 5.0.0`
- `build-tools 30.0.3`
- `platforms android-30`
- `ndk 21.4.7075529` (unchanged)

Built successfully on hosts:

- `Ubuntu 20.04 (amd64)`
  - `linux-bin ✅`
  - `android-bin ✅`
  - `android-app ✅`
- `macOS 11 (Intel)`
  - `macos-bin ✅`
  - `android-bin ❌`
  - `android-app ❌`
- `macOS 12.2 (Apple Silicon)`
  - `macos-bin ✅`
  - `android-bin ❌`
  - `android-app ❌`

I also added actions to build on more platforms:

- `android-bin`
- `android-app`
- `linux-amd64`
- `macos-amd64`

GitHub Actions also uploads artifacts for download nightly builds now.
