### PR TITLE
Fix to return nullopt when DTX is enabled and audio data is silence

### DIFF
--- a/lyra_encoder.cc
+++ b/lyra_encoder.cc
@@ -133,10 +133,9 @@ std::optional<std::vector<uint8_t>> LyraEncoder::Encode(
       LOG(ERROR) << "Unable to update encoder noise estimator.";
       return std::nullopt;
     }
-    // We send an empty packet only if this hop is just noise.
+    // We return nullopt if this hop is just noise.
     if (noise_estimator_->is_noise()) {
-      auto empty_packet = Packet<0>::Create(0, 0);
-      return empty_packet->PackQuantized(std::bitset<0>{}.to_string());
+      return std::nullopt;
     }
   }
 


### PR DESCRIPTION
Seeing lyra_encoder.h (see code block below), the Encode method seems to return `nullopt` if DTX is enabled and the input data contains only silence (noise). However, the current implementation returns an empty vector in the case.
This PR fixes the implementation to align with the specification (i.e., the doc in the header file).

```c++
  /// Encodes the audio samples into a vector wrapped byte array.
  ///
  /// @param audio Span of int16-formatted samples. It is assumed to contain
  ///              20ms of data at the sample rate chosen at Create time.
  /// @return Encoded packet as a vector of bytes as long as the right amount of
  ///         data is provided. Else it returns nullopt. It also returns nullopt
  ///         if DTX is enabled and the packet is deemed to contain silence.
  std::optional<std::vector<uint8_t>> Encode(
      const absl::Span<const int16_t> audio) override;
```

Feel free to close this PR if the current implementation is corrent and the doc should be modified.
