### PR TITLE
Fix Build Failed on Linux

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,7 +97,7 @@ git_repository(
 )
 # Dependency for glog
 git_repository(
-    name = "com_github_gflags_gflags",
+    name = "gflags",
     remote = "https://github.com/mchinen/gflags.git",
     branch = "android_linking_fix"
 )


### PR DESCRIPTION
When I build lyra on Linux, I miss ERROR as "no such package '@gflags//': The repository '@gflags' could not be resolved: Repository '@gflags' is not defined and referenced by '@com_google_glog//:glog'".Check glog repo's WORKSPACE.bazel line 6 : bazel_dep(name = "gflags", version = "2.2.2"), so I fix this problem through change lyra repo's WORKSPACE.bazel line 100: name = "com_github_gflags_gflags", to name = "gflags", now it works well.(2024-08-20)